### PR TITLE
add support for persistgraphql, optional, default not enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 npm-debug.*
 *.sqlite3
 .DS_Store
+
+extracted_queries.json

--- a/README.md
+++ b/README.md
@@ -56,10 +56,22 @@
   ```
   yarn start
   ```
+  
+6. [Optional] Extract queries for PersistGraphQL to work.
 
-6. Point your browser to [http://localhost:3000](http://localhost:3000)
-7. Change any app code and see the changes applied immediately!
-8. Open app in multiple tabs, try to increase counter in one tab and then switch to another tab. You will see that 
+    ```
+    npm run persistgraphql
+    ```
+    or
+    ```
+    yarn persistgraphql
+    ```
+    
+    Set package.json `persistedQueries` field to `true`
+
+7. Point your browser to [http://localhost:3000](http://localhost:3000)
+8. Change any app code and see the changes applied immediately!
+9. Open app in multiple tabs, try to increase counter in one tab and then switch to another tab. You will see that 
 counter value updated there as well, because counter is live updated via subscriptions.
 
 ## Deploying to [Heroku]
@@ -115,6 +127,10 @@ GraphQL requests are batched together automatically by [Apollo]
   
   GraphQL subscription is utilized to make counter updating in real-time.
 
+- [PersistGraphQL] is a simple build tool that enables query whitelisting and persisted queries for GraphQL projects that use statically analyze-able GraphQL queries.
+
+  If you would like to enable PersistGraphQL, set package.json `persistedQueries` field to `true`
+
 - SQL and arbitrary data sources support
 
   [Knex] code to access SQLite is included as an example of using arbitrary data source with [Apollo] and [GraphQL]. 
@@ -137,6 +153,7 @@ Copyright © 2016 [SysGears INC]. This source code is licensed under the [MIT] l
 [Universal]: https://medium.com/@mjackson/universal-javascript-4761051b7ae9
 [Apollo]: http://www.apollostack.com
 [GraphQL]: http://graphql.org
+[PersistGraphQL]: https://github.com/apollographql/persistgraphql
 [React]: https://facebook.github.io/react
 [Redux]: http://redux.js.org
 [Express]: http://expressjs.com

--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
     "webpackDevPort": 3000,
     "apiPort": 8080,
     "ssr": true,
-    "webpackDll": true
+    "webpackDll": true,
+    "persistedQueries": false
   },
   "engines": {
     "node": "6.6.0",
     "npm": "3.10.3"
   },
   "scripts": {
+    "persistgraphql": "persistgraphql src/ui --add_typename",
     "build": "babel-node tools/webpack.run build",
     "clean": "rm -rf $npm_package_app_frontendBuildDir $npm_package_app_backendBuildDir",
     "start": "if [ \"$NODE_ENV\" = production ]; then node --harmony $npm_package_app_backendBuildDir; else babel-node tools/webpack.run watch; fi",
@@ -46,7 +48,7 @@
   "license": "MIT",
   "dependencies": {
     "aphrodite": "^1.0.0",
-    "apollo-client": "^0.8.6",
+    "apollo-client": "^0.8.7",
     "body-parser": "^1.15.2",
     "bootstrap": "^4.0.0-alpha.6",
     "classnames": "^2.2.5",
@@ -59,12 +61,14 @@
     "graphql-typings": "0.0.1-beta-2",
     "isomorphic-fetch": "^2.2.1",
     "knex": "^0.12.1",
+    "lodash": "^4.17.4",
     "minilog": "^3.0.1",
+    "persistgraphql": "^0.3.0",
     "react": "^15.4.2",
     "react-addons-css-transition-group": "^15.4.2",
     "react-addons-transition-group": "^15.4.2",
     "react-addons-update": "^15.3.2",
-    "react-apollo": "^0.11.1",
+    "react-apollo": "^0.11.2",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.2",
     "react-router": "^3.0.2",

--- a/src/client/main.jsx
+++ b/src/client/main.jsx
@@ -7,8 +7,10 @@ import { syncHistoryWithStore } from 'react-router-redux'
 import createApolloClient from '../apollo_client'
 import createReduxStore from '../redux_store'
 import addGraphQLSubscriptions from './subscriptions'
+import { addPersistedQueries } from 'persistgraphql'
 import routes from '../routes'
-import { app as settings} from '../../package.json'
+import { app as settings } from '../../package.json'
+import queryMap from '../../extracted_queries.json'
 
 import '../ui/bootstrap.scss'
 import '../ui/styles.scss'
@@ -38,6 +40,10 @@ if (__CLIENT__) {
     networkInterface,
     wsClient,
   );
+}
+
+if (settings.persistedQueries) {
+  networkInterface = addPersistedQueries(networkInterface, queryMap);
 }
 
 const client = createApolloClient(networkInterface);

--- a/src/server/middleware/website.jsx
+++ b/src/server/middleware/website.jsx
@@ -15,6 +15,9 @@ import routes from '../../routes'
 import log from '../../log'
 import { app as settings } from '../../../package.json'
 
+import { addPersistedQueries } from 'persistgraphql'
+import queryMap from '../../../extracted_queries.json'
+
 const port = process.env.PORT || settings.apiPort;
 
 const apiUrl = `http://localhost:${port}/graphql`;
@@ -29,14 +32,21 @@ export default (req, res) => {
       log.error('ROUTER ERROR:', error);
       res.status(500);
     } else if (__SSR__ && renderProps) {
-      const client = createApolloClient(createBatchingNetworkInterface({
+
+      let networkInterface = createBatchingNetworkInterface({
         uri: apiUrl,
         opts: {
           credentials: "same-origin",
           headers: req.headers,
         },
         batchInterval: 20,
-      }));
+      });
+
+      if (settings.persistedQueries) {
+        networkInterface = addPersistedQueries(networkInterface, queryMap);
+      }
+
+      const client = createApolloClient(networkInterface);
 
       let initialState = {};
       const store = createReduxStore(initialState, client);
@@ -71,7 +81,7 @@ export default (req, res) => {
       if (__DEV__ || !assetMap) {
         assetMap = JSON.parse(fs.readFileSync(path.join(settings.frontendBuildDir, 'assets.json')));
       }
-      const page = <Html content="" state={({})} assetMap={assetMap} aphroditeCss="" />;
+      const page = <Html content="" state={({})} assetMap={assetMap} aphroditeCss=""/>;
       res.send(`<!doctype html>\n${ReactDOM.renderToStaticMarkup(page)}`);
       res.end();
     } else {


### PR DESCRIPTION
Please take a look if this would be a meaningful addition for the starter kit.

I set the `persistgraphql` to false by default and added notes how to enable it and make it work.