### PR TITLE
Follow GCC naming convention for 'front/back'-end phrasing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-## Apollo Universal Starter Kit with Hot Code Reload of backend & frontend 
+## Apollo Universal Starter Kit with back-end & front-end Hot Code Reload
 [![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors)
 [![Build Status](https://travis-ci.org/sysgears/apollo-fullstack-starter-kit.svg?branch=master)](https://travis-ci.org/sysgears/apollo-fullstack-starter-kit)
 [![Greenkeeper badge](https://badges.greenkeeper.io/sysgears/apollo-fullstack-starter-kit.svg)](https://greenkeeper.io/)
 
-> Apollo Universal Starter Kit is an boilerplate for [Universal] web app development built on top of [Apollo], 
-> [GraphQL], [React], [Redux], [Express] with SQL storage support and [Twitter Bootstrap] integration. 
-> Hot Code Reload of backend & frontend using [Webpack] and Hot Module Replacement to reflect your changes instantly 
+> Apollo Universal Starter Kit is an boilerplate for [Universal] web app development built on top of [Apollo],
+> [GraphQL], [React], [Redux], [Express] with SQL storage support and [Twitter Bootstrap] integration.
+> Hot Code Reload of back end & front end using [Webpack] and Hot Module Replacement to reflect your changes instantly
 > and help you stay productive.
 
 ## Hot Code Reload demo
@@ -25,7 +25,7 @@
   ```
   npm i
   ```
-  or 
+  or
   ```
   yarn
   ```
@@ -52,7 +52,7 @@
 
 6. Point your browser to [http://localhost:3000](http://localhost:3000)
 7. Change any app code and see the changes applied immediately!
-8. Open app in multiple tabs, try to increase counter in one tab and then switch to another tab. You will see that 
+8. Open app in multiple tabs, try to increase counter in one tab and then switch to another tab. You will see that
 counter value updated there as well, because counter is live updated via subscriptions.
 
 ## Deployment to Production
@@ -70,7 +70,7 @@ counter value updated there as well, because counter is live updated via subscri
   ```
   npm i
   ```
-  or 
+  or
   ```
   yarn
   ```
@@ -89,11 +89,11 @@ counter value updated there as well, because counter is live updated via subscri
   ```
   npm run build
   ```
-  or 
+  or
   ```
   yarn build
   ```
-  
+
 6. Run project in production mode.
 
   ```
@@ -107,69 +107,69 @@ counter value updated there as well, because counter is live updated via subscri
   ```
   yarn start
   ```
-  
+
 ### Deploying to [Heroku]
 1. Add your app to Heroku
 1. Allow Heroku to install build time dependencies from the devDependencies in package.json:
    `Settings -> Config Variables -> Add`, KEY: `NPM_CONFIG_PRODUCTION`, VALUE: `false`.
 1. Deploy your app on Heroku
 
-## Heroku Demo 
+## Heroku Demo
 You can see latest version of this app deployed to Heroku here:
 [https://apollo-fullstack-starter-kit.herokuapp.com](https://apollo-fullstack-starter-kit.herokuapp.com)
 
 ## Features
-- [Webpack] for backend
+- [Webpack] for back end
 
-  This starter kit is different from most of the starter kits out there, because it uses Webpack not only for frontend,
-but for backend code as well. This enables powerful Webpack features for backend code, such as conditional compilation, 
+  This starter kit is different from most of the starter kits out there, because it uses Webpack not only for front end,
+but for back-end code as well. This enables powerful Webpack features for back-end code, such as conditional compilation,
 embedding non-js files and CSS stylesheets into the code, hot code reload, etc.
 
-- Hot Code Reload for backend and frontend
-  
-  Hot Code Reload for backend is done using [Webpack]. When Webpack prepares hot patches on the filesystem,
-SIGUSR2 signal is sent to Node.js app and embedded Webpack Hot Module Runtime reacts to this signal and 
-applies patches to running modules from filesystem. Hot code reload for frontend is using Webpack Dev Server
-and Hot Module Replacement to apply patches to frontend code. Hot patches for React components are applied on the 
-frontend and backend at the same time, so React should not complain about differences in client and server code.
+- Hot Code Reload for back end and front end
+
+  Hot Code Reload for back end is done using [Webpack]. When Webpack prepares hot patches on the filesystem,
+SIGUSR2 signal is sent to Node.js app and embedded Webpack Hot Module Runtime reacts to this signal and
+applies patches to running modules from filesystem. Hot code reload for front end is using Webpack Dev Server
+and Hot Module Replacement to apply patches to front-end code. Hot patches for React components are applied on the
+front end and back end at the same time, so React should not complain about differences in client and server code.
 
 - Webpack DLL vendor bundle generation and updating out of the box
 
-  For all the non-development dependencies of project `package.json` the [Webpack] vendor DLL bundle is generated 
+  For all the non-development dependencies of project `package.json` the [Webpack] vendor DLL bundle is generated
   and updated automatically, so that Webpack didn't process vendor libraries on each change to the project, but only
   when they are actually changed. This boosts speed of cold project start in development mode and speed of hot code reload
   even if the number of dependencies is huge.
 
 - Server Side Rendering with Apollo Redux Store sync
 
-  On the initial web page request backend fully renders UI and hands off Apollo Redux Store state to frontend. Frontend
+  On the initial web page request back end fully renders UI and hands off Apollo Redux Store state to front end. Frontend
 then starts off from there and updates itself on user interactions.
 
   If you don't need Server Side Rendering, set package.json `ssr` field to `false`
 
 - Optimistic UI updates
 
-  This example application uses Apollo optimistic UI updates, that result in immediate UI update on user interaction and then, 
+  This example application uses Apollo optimistic UI updates, that result in immediate UI update on user interaction and then,
 after data arrives from the server, UI state is finalized.
 
 - [GraphQL] API
 
-  GraphQL is used as very flexible and much faster API in terms of bandwidth and round-trips, compared to REST. 
+  GraphQL is used as very flexible and much faster API in terms of bandwidth and round-trips, compared to REST.
 GraphQL requests are batched together automatically by [Apollo]
 
 - [GraphQL] subscription example
-  
+
   GraphQL subscription is utilized to make counter updating in real-time.
 
 - SQL and arbitrary data sources support
 
-  [Knex] code to access SQLite is included as an example of using arbitrary data source with [Apollo] and [GraphQL]. 
+  [Knex] code to access SQLite is included as an example of using arbitrary data source with [Apollo] and [GraphQL].
 NoSQL storage or any other data source can be used the same way.
 
 - Powerful stylesheets with Hot Reloading
 
   [Twitter Bootstrap] in form of SASS stylesheets is used for styling demo application. Application has stylesheet
-in `styles.scss` for global styling which is Hot Reloaded on change. React components styling is done by [Aphrodite CSS].` 
+in `styles.scss` for global styling which is Hot Reloaded on change. React components styling is done by [Aphrodite CSS].`
 
 - [Babel] for ES2017 transpiling
 
@@ -204,4 +204,3 @@ Copyright © 2016 [SysGears INC]. This source code is licensed under the [MIT] l
 [Heroku]: https://heroku.com
 [ESLint]: http://eslint.org
 [SysGears INC]: http://sysgears.com
-


### PR DESCRIPTION
Hey guys I rephrased a few items in the README to follow closely to the [GCC naming convention](https://gcc.gnu.org/codingconventions.html#Spelling). Namely, using "front end"/"back end" for nouns and the hyphenated equivalent when acting as adjectives. Let me know if you have any questions.