### PR TITLE
subscriptions on post comments

### DIFF
--- a/src/server/api/graphqls/post_def.graphqls
+++ b/src/server/api/graphqls/post_def.graphqls
@@ -73,3 +73,13 @@ input EditCommentInput {
   id: ID!
   content: String!
 }
+
+extend type Subscription {
+  commentUpdated(commentIds: [ID!]): UpdateCommentPayload
+}
+
+type UpdateCommentPayload {
+  mutation: String!
+  node: Comment
+  previousValue: Comment
+}

--- a/src/server/api/graphqls/post_def.graphqls
+++ b/src/server/api/graphqls/post_def.graphqls
@@ -48,7 +48,7 @@ extend type Mutation {
   # Add comment to post
   addComment(input: AddCommentInput!): Comment
   # Delete a comment
-  deleteComment(id: ID!): Comment
+  deleteComment(input: DeleteCommentInput!): Comment
   # Edit a comment
   editComment(input: EditCommentInput!): Comment
 }
@@ -65,21 +65,27 @@ input EditPostInput {
 }
 
 input AddCommentInput {
+  postId: ID!
   content: String!
+}
+
+input DeleteCommentInput {
+  id: ID!
   postId: ID!
 }
 
 input EditCommentInput {
   id: ID!
+  postId: ID!
   content: String!
 }
 
 extend type Subscription {
-  commentUpdated(commentIds: [ID!]): UpdateCommentPayload
+  commentUpdated(postId: ID!): UpdateCommentPayload
 }
 
 type UpdateCommentPayload {
   mutation: String!
+  id: ID
   node: Comment
-  previousValue: Comment
 }

--- a/src/server/api/resolvers/post_resolvers.js
+++ b/src/server/api/resolvers/post_resolvers.js
@@ -1,6 +1,6 @@
 import { pubsub } from '../schema'
 
-export const postResolvers = {
+const postResolvers = {
   Query: {
     postsQuery(obj, { first, after }, context) {
       let edgesArray = [];
@@ -70,14 +70,14 @@ export const postResolvers = {
       return context.Post.addComment(input)
         .then((id) => context.Post.getComment(id[ 0 ]))
         .then(comment => {
-          pubsub.publish('commentUpdated', { mutation: 'CREATED', node: comment, previousValue: null });
+          pubsub.publish('commentUpdated', { mutation: 'CREATED', id: comment.id, postId: input.postId, node: comment });
           return comment;
         });
     },
-    deleteComment(obj, { id }, context) {
+    deleteComment(obj, { input: { id, postId } }, context) {
       return context.Post.deleteComment(id)
         .then(() => {
-          pubsub.publish('commentUpdated', { mutation: 'DELETED', node: null, previousValue: { id, content: '' } });
+          pubsub.publish('commentUpdated', { mutation: 'DELETED', id, postId, node: null });
           return { id };
         });
     },
@@ -85,7 +85,7 @@ export const postResolvers = {
       return context.Post.editComment(input)
         .then(() => context.Post.getComment(input.id))
         .then(comment => {
-          pubsub.publish('commentUpdated', { mutation: 'UPDATED', node: comment, previousValue: null });
+          pubsub.publish('commentUpdated', { mutation: 'UPDATED', id: input.id, postId: input.postId, node: comment });
           return comment;
         });
     },
@@ -96,3 +96,5 @@ export const postResolvers = {
     },
   }
 };
+
+export default postResolvers;

--- a/src/server/api/resolvers/post_resolvers.js
+++ b/src/server/api/resolvers/post_resolvers.js
@@ -1,4 +1,6 @@
-export const resolvers = {
+import { pubsub } from '../schema'
+
+export const postResolvers = {
   Query: {
     postsQuery(obj, { first, after }, context) {
       let edgesArray = [];
@@ -68,14 +70,14 @@ export const resolvers = {
       return context.Post.addComment(input)
         .then((id) => context.Post.getComment(id[ 0 ]))
         .then(comment => {
-          //pubsub.publish('addComment', comment);
+          pubsub.publish('commentUpdated', { mutation: 'CREATED', node: comment, previousValue: null });
           return comment;
         });
     },
     deleteComment(obj, { id }, context) {
       return context.Post.deleteComment(id)
         .then(() => {
-          //pubsub.publish('deleteComment', id);
+          pubsub.publish('commentUpdated', { mutation: 'DELETED', node: null, previousValue: { id, content: '' } });
           return { id };
         });
     },
@@ -83,9 +85,14 @@ export const resolvers = {
       return context.Post.editComment(input)
         .then(() => context.Post.getComment(input.id))
         .then(comment => {
-          //pubsub.publish('editComment', post);
+          pubsub.publish('commentUpdated', { mutation: 'UPDATED', node: comment, previousValue: null });
           return comment;
         });
+    },
+  },
+  Subscription: {
+    commentUpdated(value) {
+      return value;
     },
   }
 };

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -4,7 +4,7 @@ import { merge } from 'lodash';
 
 import log from '../../log'
 
-import { resolvers as postResolvers } from './resolvers/post_resolvers';
+import { postResolvers } from './resolvers/post_resolvers';
 
 import schema from './graphqls/schema_def.graphqls'
 import postSchema from './graphqls/post_def.graphqls'

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1,10 +1,9 @@
 import { makeExecutableSchema, addErrorLoggingToSchema } from 'graphql-tools'
 import { PubSub } from 'graphql-subscriptions'
-import { merge } from 'lodash';
+import { merge } from 'lodash'
 
 import log from '../../log'
-
-import { postResolvers } from './resolvers/post_resolvers';
+import postResolvers from './resolvers/post_resolvers'
 
 import schema from './graphqls/schema_def.graphqls'
 import postSchema from './graphqls/post_def.graphqls'

--- a/src/server/api/subscriptions.js
+++ b/src/server/api/subscriptions.js
@@ -1,18 +1,23 @@
 import { SubscriptionManager } from 'graphql-subscriptions'
+import { merge } from 'lodash'
+
 import schema, { pubsub } from './schema'
+
+import postSetupFunctions from './subscriptions/post_subscriptions'
+
+const rootSetupFunctions = {
+  countUpdated: () => ({
+    // Run the query each time count updated
+    countUpdated: () => true
+  })
+};
+
+const setupFunctions = merge(rootSetupFunctions, postSetupFunctions);
 
 const subscriptionManager = new SubscriptionManager({
   schema,
   pubsub,
-  setupFunctions: {
-    countUpdated: () => ({
-      // Run the query each time count updated
-      countUpdated: () => true
-    }),
-    commentUpdated: () => ({
-      commentUpdated: () => true,
-    }),
-  },
+  setupFunctions,
 });
 
 export { subscriptionManager, pubsub };

--- a/src/server/api/subscriptions.js
+++ b/src/server/api/subscriptions.js
@@ -8,7 +8,10 @@ const subscriptionManager = new SubscriptionManager({
     countUpdated: () => ({
       // Run the query each time count updated
       countUpdated: () => true
-    })
+    }),
+    commentUpdated: () => ({
+      commentUpdated: () => true,
+    }),
   },
 });
 

--- a/src/server/api/subscriptions/post_subscriptions.js
+++ b/src/server/api/subscriptions/post_subscriptions.js
@@ -1,0 +1,9 @@
+const postSetupFunctions = {
+  commentUpdated: (options, args) => ({
+    commentUpdated: {
+      filter: comment => args.postId === comment.postId
+    },
+  }),
+};
+
+export default  postSetupFunctions;

--- a/src/server/sql/post.js
+++ b/src/server/sql/post.js
@@ -72,7 +72,7 @@ export default class Post {
       });
   }
 
-  addComment({content, postId}) {
+  addComment({ content, postId }) {
     return knex('comment').insert({ content, post_id: postId });
   }
 
@@ -88,7 +88,7 @@ export default class Post {
     return knex('comment').where('id', '=', id).del();
   }
 
-  editComment({id, content}) {
+  editComment({ id, content }) {
     return knex('comment')
       .where('id', '=', id)
       .update({

--- a/src/ui/post/components/post_comment_form.jsx
+++ b/src/ui/post/components/post_comment_form.jsx
@@ -43,6 +43,12 @@ const CommentForm = (props) => {
   );
 };
 
+CommentForm.propTypes = {
+  handleSubmit: React.PropTypes.func,
+  initialValues: React.PropTypes.object,
+  onSubmit: React.PropTypes.func,
+};
+
 export default reduxForm({
   form: 'comment',
   enableReinitialize: true

--- a/src/ui/post/components/post_form.jsx
+++ b/src/ui/post/components/post_form.jsx
@@ -35,6 +35,11 @@ const PostForm = (props) => {
   );
 };
 
+PostForm.propTypes = {
+  handleSubmit: React.PropTypes.func,
+  onSubmit: React.PropTypes.func,
+};
+
 export default reduxForm({
   form: 'post'
 })(PostForm);

--- a/src/ui/post/containers/post_add.jsx
+++ b/src/ui/post/containers/post_add.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { graphql, compose, withApollo } from 'react-apollo'
+import { graphql, compose } from 'react-apollo'
 import update from 'react-addons-update'
 import { Link } from 'react-router-dom'
 
@@ -29,7 +29,7 @@ PostAdd.propTypes = {
   addPost: React.PropTypes.func.isRequired,
 };
 
-const PostAddWithApollo = withApollo(compose(
+const PostAddWithApollo = compose(
   graphql(POST_ADD, {
     props: ({ ownProps, mutate }) => ({
       addPost: (title, content) => mutate({
@@ -72,6 +72,6 @@ const PostAddWithApollo = withApollo(compose(
       }).then(() => ownProps.history.push('/posts')),
     })
   })
-)(PostAdd));
+)(PostAdd);
 
 export default PostAddWithApollo;

--- a/src/ui/post/containers/post_comments.jsx
+++ b/src/ui/post/containers/post_comments.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { graphql, compose, withApollo } from 'react-apollo'
+import { graphql, compose } from 'react-apollo'
 import update from 'react-addons-update'
 import { reset } from 'redux-form'
 import { ListGroup, ListGroupItem } from 'reactstrap'
@@ -10,23 +10,93 @@ import CommentForm from '../components/post_comment_form'
 import COMMENT_ADD from '../graphql/post_comment_add.graphql'
 import COMMENT_EDIT from '../graphql/post_comment_edit.graphql'
 import COMMENT_DELETE from '../graphql/post_comment_delete.graphql'
+import COMMENT_SUBSCRIPTION from '../graphql/post_comment_subscription.graphql'
+
+function isDuplicateComment(newComment, existingComments) {
+  return newComment.id !== null && existingComments.some(comment => newComment.id === comment.id);
+}
 
 class PostComments extends React.Component {
   constructor(props) {
     super(props);
 
     props.onCommentSelect({ id: null, content: '' });
+    this.subscription = null;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // Check if props have changed and, if necessary, stop the subscription
+    if (this.subscription && this.props.comments !== nextProps.comments) {
+      this.subscription.unsubscribe();
+      this.subscription = null;
+    }
+
+    let commentIds = [];
+    nextProps.comments.map(comment => {
+      commentIds.push(parseInt(comment.id));
+    });
+
+    // Subscribe or re-subscribe
+    if (!this.subscription) {
+      this.systemsSub = nextProps.subscribeToMore({
+        document: COMMENT_SUBSCRIPTION,
+        variables: { commentIds: commentIds },
+        updateQuery: (prev, { subscriptionData: { data: { commentUpdated: { mutation, node, previousValue } } } }) => {
+
+          let newResult;
+
+          if (mutation == 'CREATED') {
+
+            if (isDuplicateComment(node, prev.post.comments)) {
+              return prev;
+            }
+
+            newResult = update(prev, {
+              post: {
+                comments: {
+                  $push: [ node ],
+                }
+              }
+            });
+          } else if (mutation == 'DELETED') {
+            const index = prev.post.comments.findIndex(x => x.id == previousValue.id);
+
+            if (index >= 0) {
+              newResult = update(prev, {
+                post: {
+                  comments: {
+                    $splice: [ [ index, 1 ] ],
+                  }
+                }
+              });
+            }
+          } else {
+            newResult = prev;
+          }
+
+          return newResult;
+        },
+        onError: (err) => console.error(err),
+      });
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 
   renderComments() {
-    const { comments, deleteComment, onCommentSelect } = this.props;
+    const { comments, onCommentSelect } = this.props;
 
     return comments.map(({ id, content }) => {
       return (
         <ListGroupItem className="justify-content-between" key={id}>
           {content}
           <div>
-            <span className="badge badge-default badge-pill" onClick={() => onCommentSelect({ id, content })}>Edit</span>
+            <span className="badge badge-default badge-pill"
+                  onClick={() => onCommentSelect({ id, content })}>Edit</span>
             <span className="badge badge-default badge-pill" onClick={() => this.onCommentDelete(id)}>Delete</span>
           </div>
         </ListGroupItem>
@@ -37,7 +107,7 @@ class PostComments extends React.Component {
   onCommentDelete(id) {
     const { comment, deleteComment, onCommentSelect } = this.props;
 
-    if ( comment.id === id) {
+    if (comment.id === id) {
       onCommentSelect({ id: null, content: '' });
     }
 
@@ -81,11 +151,12 @@ PostComments.propTypes = {
   deleteComment: React.PropTypes.func.isRequired,
   onCommentSelect: React.PropTypes.func.isRequired,
   onFormSubmitted: React.PropTypes.func.isRequired,
+  subscribeToMore: React.PropTypes.func.isRequired,
 };
 
-const PostCommentsWithApollo = withApollo(compose(
+const PostCommentsWithApollo = compose(
   graphql(COMMENT_ADD, {
-    props: ({ ownProps, mutate }) => ({
+    props: ({ mutate }) => ({
       addComment: (content, postId) => mutate({
         variables: { input: { content, postId } },
         optimisticResponse: {
@@ -96,11 +167,16 @@ const PostCommentsWithApollo = withApollo(compose(
           },
         },
         updateQueries: {
-          getPost: (prev, { mutationResult }) => {
+          getPost: (prev, { mutationResult: { data: { addComment } } }) => {
+
+            if (isDuplicateComment(addComment, prev.post.comments)) {
+              return prev;
+            }
+
             return update(prev, {
               post: {
                 comments: {
-                  $push: [ mutationResult.data.addComment ],
+                  $push: [ addComment ],
                 }
               }
             });
@@ -110,7 +186,7 @@ const PostCommentsWithApollo = withApollo(compose(
     })
   }),
   graphql(COMMENT_EDIT, {
-    props: ({ ownProps, mutate }) => ({
+    props: ({ mutate }) => ({
       editComment: (id, content) => mutate({
         variables: { input: { id, content } },
         optimisticResponse: {
@@ -125,7 +201,7 @@ const PostCommentsWithApollo = withApollo(compose(
     })
   }),
   graphql(COMMENT_DELETE, {
-    props: ({ ownProps, mutate }) => ({
+    props: ({ mutate }) => ({
       deleteComment: (id) => mutate({
         variables: { id },
         optimisticResponse: {
@@ -136,22 +212,24 @@ const PostCommentsWithApollo = withApollo(compose(
           },
         },
         updateQueries: {
-          getPost: (prev, { mutationResult }) => {
-            const index = prev.post.comments.findIndex(x => x.id == mutationResult.data.deleteComment.id);
+          getPost: (prev, { mutationResult: { data: { deleteComment } } }) => {
+            const index = prev.post.comments.findIndex(x => x.id == deleteComment.id);
 
-            return update(prev, {
-              post: {
-                comments: {
-                  $splice: [ [ index, 1 ] ],
+            if (index >= 0) {
+              return update(prev, {
+                post: {
+                  comments: {
+                    $splice: [ [ index, 1 ] ],
+                  }
                 }
-              }
-            });
+              });
+            }
           }
         }
       }),
     })
   })
-)(PostComments));
+)(PostComments);
 
 export default connect(
   (state) => ({ comment: state.post.comment }),

--- a/src/ui/post/containers/post_edit.jsx
+++ b/src/ui/post/containers/post_edit.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { graphql, compose, withApollo } from 'react-apollo'
+import { graphql, compose } from 'react-apollo'
 import { Link } from 'react-router-dom'
 
 import PostForm from '../components/post_form'
@@ -16,7 +16,7 @@ class PostEdit extends React.Component {
   }
 
   render() {
-    const { loading, post, match } = this.props;
+    const { loading, post, match, subscribeToMore } = this.props;
 
     if (loading) {
       return (
@@ -29,7 +29,7 @@ class PostEdit extends React.Component {
           <h2>Edit Post</h2>
           <PostForm onSubmit={this.onSubmit.bind(this)} initialValues={post}/>
           <br/>
-          <PostComments postId={match.params.id} comments={post.comments}/>
+          <PostComments postId={match.params.id} comments={post.comments} subscribeToMore={subscribeToMore}/>
         </div>
       );
     }
@@ -40,17 +40,19 @@ PostEdit.propTypes = {
   loading: React.PropTypes.bool.isRequired,
   post: React.PropTypes.object,
   editPost: React.PropTypes.func.isRequired,
+  match: React.PropTypes.object.isRequired,
+  subscribeToMore: React.PropTypes.func.isRequired,
 };
 
-const PostEditWithApollo = withApollo(compose(
+const PostEditWithApollo = compose(
   graphql(POST_QUERY, {
     options: (props) => {
       return {
         variables: { id: props.match.params.id }
       };
     },
-    props({ data: { loading, post } }) {
-      return { loading, post };
+    props({ data: { loading, post, subscribeToMore } }) {
+      return { loading, post, subscribeToMore };
     }
   }),
   graphql(POST_EDIT, {
@@ -60,6 +62,6 @@ const PostEditWithApollo = withApollo(compose(
       }).then(() => ownProps.history.push('/posts')),
     })
   })
-)(PostEdit));
+)(PostEdit);
 
 export default PostEditWithApollo;

--- a/src/ui/post/containers/post_list.jsx
+++ b/src/ui/post/containers/post_list.jsx
@@ -129,8 +129,8 @@ const PostListWithApollo = compose(
             },
           },
           updateQueries: {
-            getPosts: (prev, { mutationResult }) => {
-              const index = prev.postsQuery.edges.findIndex(x => x.node.id == mutationResult.data.deletePost.id);
+            getPosts: (prev, { mutationResult: { data: { deletePost } } }) => {
+              const index = prev.postsQuery.edges.findIndex(x => x.node.id === deletePost.id);
 
               return update(prev, {
                 postsQuery: {

--- a/src/ui/post/containers/post_list.jsx
+++ b/src/ui/post/containers/post_list.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { graphql, compose, withApollo } from 'react-apollo'
+import { graphql, compose } from 'react-apollo'
 import update from 'react-addons-update'
 import { css } from 'glamor'
 import { Link } from 'react-router-dom'
@@ -77,9 +77,10 @@ PostList.propTypes = {
   loading: React.PropTypes.bool.isRequired,
   postsQuery: React.PropTypes.object,
   deletePost: React.PropTypes.func.isRequired,
+  loadMoreRows: React.PropTypes.func.isRequired,
 };
 
-const PostListWithApollo = withApollo(compose(
+const PostListWithApollo = compose(
   graphql(POSTS_QUERY, {
     options: (props) => {
       let after = props.endCursor || 0;
@@ -87,7 +88,7 @@ const PostListWithApollo = withApollo(compose(
         variables: { first: 10, after: after },
       };
     },
-    props: ({ ownProps, data }) => {
+    props: ({ data }) => {
       const { loading, postsQuery, fetchMore } = data;
       const loadMoreRows = () => {
         return fetchMore({
@@ -116,7 +117,7 @@ const PostListWithApollo = withApollo(compose(
     }
   }),
   graphql(POST_DELETE, {
-    props: ({ ownProps, mutate }) => ({
+    props: ({ mutate }) => ({
       deletePost(id){
         return () => mutate({
           variables: { id },
@@ -147,6 +148,6 @@ const PostListWithApollo = withApollo(compose(
       },
     })
   })
-)(PostList));
+)(PostList);
 
 export default PostListWithApollo;

--- a/src/ui/post/graphql/post_comment_delete.graphql
+++ b/src/ui/post/graphql/post_comment_delete.graphql
@@ -1,5 +1,5 @@
-mutation deleteComment($id: ID!) {
-    deleteComment(id: $id) {
+mutation deleteComment($input: DeleteCommentInput!) {
+    deleteComment(input: $input) {
         id
     }
 }

--- a/src/ui/post/graphql/post_comment_subscription.graphql
+++ b/src/ui/post/graphql/post_comment_subscription.graphql
@@ -1,0 +1,13 @@
+#import "./comment.graphql"
+
+subscription onCommentUpdated($commentIds: [ID!]) {
+    commentUpdated(commentIds: $commentIds) {
+        mutation
+        node {
+            ... CommentInfo
+        }
+        previousValue {
+            ... CommentInfo
+        }
+    }
+}

--- a/src/ui/post/graphql/post_comment_subscription.graphql
+++ b/src/ui/post/graphql/post_comment_subscription.graphql
@@ -1,12 +1,10 @@
 #import "./comment.graphql"
 
-subscription onCommentUpdated($commentIds: [ID!]) {
-    commentUpdated(commentIds: $commentIds) {
+subscription onCommentUpdated($postId: ID!) {
+    commentUpdated(postId: $postId) {
         mutation
+        id
         node {
-            ... CommentInfo
-        }
-        previousValue {
             ... CommentInfo
         }
     }


### PR DESCRIPTION
This is an initial draft how I am able to get CREATED, UPDATED, DELETED subscriptions working on post comments.

@vlasenko If you have some time, any feedback would be welcome.

Current TODO planed:
- move code from `subscriptions.js` into separate file, like for schema and resolvers
- figure out how to filter subscriptions if new comments are added (currently no filter is applied)
- retrieve proper `previousValue` for UPDATED and DELETED (currently not really used, except for delete id)
- make `mutation` field enum