### PR TITLE
subscriptions on edit post

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ predictable and buggy. To turn `React Hot Loader v3` on: set `reactHotLoader` fi
 
 - [GraphQL Cursor Pagination] Example of  [Relay-style cursor pagination]
 
-- [ReduxForm] Full CRUD funcionality in post example
+- Full CRUD funcionality with Subscriptions in post example, with [ReduxForm]
 
 ## Contributors
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "author": "SysGears INC",
   "license": "MIT",
   "dependencies": {
-    "apollo-client": "^1.0.0-rc.8",
+    "apollo-client": "^1.0.0-rc.9",
     "body-parser": "^1.17.1",
     "bootstrap": "^4.0.0-alpha.6",
     "dataloader": "^1.3.0",

--- a/src/database/seeds/seed.js
+++ b/src/database/seeds/seed.js
@@ -13,7 +13,7 @@ export function seed(knex, Promise) { // eslint-disable-line import/prefer-defau
 
         let posts = [];
 
-        for (let ii = 0; ii < 5; ++ii) {
+        for (let ii = 0; ii < 20; ++ii) {
           posts.push(knex('post').insert({
             title: `Post title ${ii + 1}`,
             content: `Post content ${ii + 1}`

--- a/src/server/api/graphqls/post_def.graphqls
+++ b/src/server/api/graphqls/post_def.graphqls
@@ -82,7 +82,15 @@ input EditCommentInput {
 
 extend type Subscription {
   postUpdated(id: ID!): Post
+  postsUpdated(endCursor: ID!): UpdatePostPayload
   commentUpdated(postId: ID!): UpdateCommentPayload
+}
+
+type UpdatePostPayload {
+  mutation: String!
+  id: ID
+  endCursor: ID!
+  node: Post
 }
 
 type UpdateCommentPayload {

--- a/src/server/api/graphqls/post_def.graphqls
+++ b/src/server/api/graphqls/post_def.graphqls
@@ -81,6 +81,7 @@ input EditCommentInput {
 }
 
 extend type Subscription {
+  postUpdated(id: ID!): Post
   commentUpdated(postId: ID!): UpdateCommentPayload
 }
 

--- a/src/server/api/graphqls/post_def.graphqls
+++ b/src/server/api/graphqls/post_def.graphqls
@@ -88,5 +88,6 @@ extend type Subscription {
 type UpdateCommentPayload {
   mutation: String!
   id: ID
+  postId: ID!
   node: Comment
 }

--- a/src/server/api/graphqls/post_def.graphqls
+++ b/src/server/api/graphqls/post_def.graphqls
@@ -53,46 +53,62 @@ extend type Mutation {
   editComment(input: EditCommentInput!): Comment
 }
 
+# Input for addPost Mutation
 input AddPostInput {
   title: String!
   content: String!
+  # Needed for postsUpdated Subscription filter
   endCursor: ID
 }
 
+# Input for deletePost Mutation
 input DeletePostInput {
   id: ID!
+  # Needed for postsUpdated Subscription filter
   endCursor: ID
 }
 
+# Input for editPost Mutation
 input EditPostInput {
   id: ID!
   title: String!
   content: String!
+  # Needed for postsUpdated Subscription filter
   endCursor: ID
 }
 
+# Input for addComment Mutation
 input AddCommentInput {
-  postId: ID!
   content: String!
+  # Needed for commentUpdated Subscription filter
+  postId: ID!
 }
 
+# Input for editComment Mutation
 input DeleteCommentInput {
   id: ID!
+  # Needed for commentUpdated Subscription filter
   postId: ID!
 }
 
+# Input for deleteComment Mutation
 input EditCommentInput {
   id: ID!
-  postId: ID!
   content: String!
+  # Needed for commentUpdated Subscription filter
+  postId: ID!
 }
 
 extend type Subscription {
+  # Subscription for when editing a post
   postUpdated(id: ID!): Post
+  # Subscription for post list
   postsUpdated(endCursor: ID!): UpdatePostPayload
+  # Subscription for comments
   commentUpdated(postId: ID!): UpdateCommentPayload
 }
 
+# Payload for postsUpdated Subscription
 type UpdatePostPayload {
   mutation: String!
   id: ID
@@ -100,6 +116,7 @@ type UpdatePostPayload {
   node: Post
 }
 
+# Payload for commentUpdated Subscription
 type UpdateCommentPayload {
   mutation: String!
   id: ID

--- a/src/server/api/graphqls/post_def.graphqls
+++ b/src/server/api/graphqls/post_def.graphqls
@@ -42,7 +42,7 @@ extend type Mutation {
   # Create new post
   addPost(input: AddPostInput!): Post
   # Delete a post
-  deletePost(id: ID!): Post
+  deletePost(input: DeletePostInput!): Post
   # Edit a post
   editPost(input: EditPostInput!): Post
   # Add comment to post
@@ -56,12 +56,19 @@ extend type Mutation {
 input AddPostInput {
   title: String!
   content: String!
+  endCursor: ID
+}
+
+input DeletePostInput {
+  id: ID!
+  endCursor: ID
 }
 
 input EditPostInput {
   id: ID!
   title: String!
   content: String!
+  endCursor: ID
 }
 
 input AddCommentInput {

--- a/src/server/api/resolvers/post_resolvers.js
+++ b/src/server/api/resolvers/post_resolvers.js
@@ -71,7 +71,12 @@ const postResolvers = {
       return context.Post.addComment(input)
         .then((id) => context.Post.getComment(id[ 0 ]))
         .then(comment => {
-          pubsub.publish('commentUpdated', { mutation: 'CREATED', id: comment.id, postId: input.postId, node: comment });
+          pubsub.publish('commentUpdated', {
+            mutation: 'CREATED',
+            id: comment.id,
+            postId: input.postId,
+            node: comment
+          });
           return comment;
         });
     },

--- a/src/server/api/resolvers/post_resolvers.js
+++ b/src/server/api/resolvers/post_resolvers.js
@@ -62,7 +62,7 @@ const postResolvers = {
       return context.Post.editPost(input)
         .then(() => context.Post.getPost(input.id))
         .then(post => {
-          //pubsub.publish('editPost', post);
+          pubsub.publish('postUpdated', post);
           return post;
         });
     },
@@ -91,6 +91,9 @@ const postResolvers = {
     },
   },
   Subscription: {
+    postUpdated(value) {
+      return value;
+    },
     commentUpdated(value) {
       return value;
     },

--- a/src/server/api/resolvers/post_resolvers.js
+++ b/src/server/api/resolvers/post_resolvers.js
@@ -47,6 +47,7 @@ const postResolvers = {
       return context.Post.addPost(input)
         .then((id) => context.Post.getPost(id[ 0 ]))
         .then(post => {
+          // publish for post list
           pubsub.publish('postsUpdated', { mutation: 'CREATED', id: post.id, endCursor: input.endCursor, node: post });
           return post;
         });
@@ -54,6 +55,7 @@ const postResolvers = {
     deletePost(obj, { input: { id, endCursor } }, context) {
       return context.Post.deletePost(id)
         .then(() => {
+          // publish for post list
           pubsub.publish('postsUpdated', { mutation: 'DELETED', id, endCursor: endCursor, node: null });
           return { id };
         });
@@ -62,7 +64,9 @@ const postResolvers = {
       return context.Post.editPost(input)
         .then(() => context.Post.getPost(input.id))
         .then(post => {
+          // publish for post list
           pubsub.publish('postsUpdated', { mutation: 'UPDATED', id: input.id, endCursor: input.endCursor, node: post });
+          // publish for edit post page
           pubsub.publish('postUpdated', post);
           return post;
         });
@@ -71,6 +75,7 @@ const postResolvers = {
       return context.Post.addComment(input)
         .then((id) => context.Post.getComment(id[ 0 ]))
         .then(comment => {
+          // publish for edit post page
           pubsub.publish('commentUpdated', {
             mutation: 'CREATED',
             id: comment.id,
@@ -83,6 +88,7 @@ const postResolvers = {
     deleteComment(obj, { input: { id, postId } }, context) {
       return context.Post.deleteComment(id)
         .then(() => {
+          // publish for edit post page
           pubsub.publish('commentUpdated', { mutation: 'DELETED', id, postId, node: null });
           return { id };
         });
@@ -91,6 +97,7 @@ const postResolvers = {
       return context.Post.editComment(input)
         .then(() => context.Post.getComment(input.id))
         .then(comment => {
+          // publish for edit post page
           pubsub.publish('commentUpdated', { mutation: 'UPDATED', id: input.id, postId: input.postId, node: comment });
           return comment;
         });

--- a/src/server/api/resolvers/post_resolvers.js
+++ b/src/server/api/resolvers/post_resolvers.js
@@ -47,14 +47,14 @@ const postResolvers = {
       return context.Post.addPost(input)
         .then((id) => context.Post.getPost(id[ 0 ]))
         .then(post => {
-          pubsub.publish('postsUpdated', { mutation: 'CREATED', id: post.id, endCursor: 0, node: post });
+          pubsub.publish('postsUpdated', { mutation: 'CREATED', id: post.id, endCursor: input.endCursor, node: post });
           return post;
         });
     },
-    deletePost(obj, { id }, context) {
+    deletePost(obj, { input: { id, endCursor } }, context) {
       return context.Post.deletePost(id)
         .then(() => {
-          pubsub.publish('postsUpdated', { mutation: 'DELETED', id, endCursor: 0, node: null });
+          pubsub.publish('postsUpdated', { mutation: 'DELETED', id, endCursor: endCursor, node: null });
           return { id };
         });
     },
@@ -62,7 +62,7 @@ const postResolvers = {
       return context.Post.editPost(input)
         .then(() => context.Post.getPost(input.id))
         .then(post => {
-          pubsub.publish('postsUpdated', { mutation: 'UPDATED', id: input.id, endCursor: 0, node: post });
+          pubsub.publish('postsUpdated', { mutation: 'UPDATED', id: input.id, endCursor: input.endCursor, node: post });
           pubsub.publish('postUpdated', post);
           return post;
         });

--- a/src/server/api/resolvers/post_resolvers.js
+++ b/src/server/api/resolvers/post_resolvers.js
@@ -47,14 +47,14 @@ const postResolvers = {
       return context.Post.addPost(input)
         .then((id) => context.Post.getPost(id[ 0 ]))
         .then(post => {
-          //pubsub.publish('addPost', post);
+          pubsub.publish('postsUpdated', { mutation: 'CREATED', id: post.id, endCursor: 0, node: post });
           return post;
         });
     },
     deletePost(obj, { id }, context) {
       return context.Post.deletePost(id)
         .then(() => {
-          //pubsub.publish('deletePost', id);
+          pubsub.publish('postsUpdated', { mutation: 'DELETED', id, endCursor: 0, node: null });
           return { id };
         });
     },
@@ -62,6 +62,7 @@ const postResolvers = {
       return context.Post.editPost(input)
         .then(() => context.Post.getPost(input.id))
         .then(post => {
+          pubsub.publish('postsUpdated', { mutation: 'UPDATED', id: input.id, endCursor: 0, node: post });
           pubsub.publish('postUpdated', post);
           return post;
         });
@@ -92,6 +93,9 @@ const postResolvers = {
   },
   Subscription: {
     postUpdated(value) {
+      return value;
+    },
+    postsUpdated(value) {
       return value;
     },
     commentUpdated(value) {

--- a/src/server/api/subscriptions/post_subscriptions.js
+++ b/src/server/api/subscriptions/post_subscriptions.js
@@ -4,6 +4,9 @@ const postSetupFunctions = {
       filter: post => args.id == post.id
     },
   }),
+  postsUpdated: (options, args) => ({
+    postsUpdated: () => true
+  }),
   commentUpdated: (options, args) => ({
     commentUpdated: {
       filter: comment => args.postId === comment.postId

--- a/src/server/api/subscriptions/post_subscriptions.js
+++ b/src/server/api/subscriptions/post_subscriptions.js
@@ -1,4 +1,9 @@
 const postSetupFunctions = {
+  postUpdated: (options, args) => ({
+    postUpdated: {
+      filter: post => args.id == post.id
+    },
+  }),
   commentUpdated: (options, args) => ({
     commentUpdated: {
       filter: comment => args.postId === comment.postId

--- a/src/server/api/subscriptions/post_subscriptions.js
+++ b/src/server/api/subscriptions/post_subscriptions.js
@@ -5,7 +5,9 @@ const postSetupFunctions = {
     },
   }),
   postsUpdated: (options, args) => ({
-    postsUpdated: () => true
+    postsUpdated: {
+      filter: post => args.endCursor <= post.id
+    }
   }),
   commentUpdated: (options, args) => ({
     commentUpdated: {

--- a/src/server/sql/post.js
+++ b/src/server/sql/post.js
@@ -1,5 +1,5 @@
-import knex from './connector'
 import _ from 'lodash'
+import knex from './connector'
 
 const orderedFor = (rows, collection, field, singleObject) => {
   // return the rows ordered for the collection

--- a/src/server/sql/post.js
+++ b/src/server/sql/post.js
@@ -55,8 +55,8 @@ export default class Post {
       .first();
   }
 
-  addPost(input) {
-    return knex('post').insert({ ...input });
+  addPost({ title, content }) {
+    return knex('post').insert({ title, content });
   }
 
   deletePost(id) {

--- a/src/ui/post/components/post_form.jsx
+++ b/src/ui/post/components/post_form.jsx
@@ -41,5 +41,6 @@ PostForm.propTypes = {
 };
 
 export default reduxForm({
-  form: 'post'
+  form: 'post',
+  enableReinitialize: true
 })(PostForm);

--- a/src/ui/post/containers/post_add.jsx
+++ b/src/ui/post/containers/post_add.jsx
@@ -5,7 +5,6 @@ import update from 'react-addons-update'
 import { Link } from 'react-router-dom'
 
 import PostForm from '../components/post_form'
-
 import POST_ADD from '../graphql/post_add.graphql'
 
 function isDuplicatePost(newPost, existingPosts) {
@@ -83,6 +82,5 @@ const PostAddWithApollo = compose(
 )(PostAdd);
 
 export default connect(
-  (state) => ({ endCursor: state.post.endCursor }),
-  (dispatch) => ({}),
+  (state) => ({ endCursor: state.post.endCursor })
 )(PostAddWithApollo);

--- a/src/ui/post/containers/post_add.jsx
+++ b/src/ui/post/containers/post_add.jsx
@@ -7,6 +7,10 @@ import PostForm from '../components/post_form'
 
 import POST_ADD from '../graphql/post_add.graphql'
 
+function isDuplicatePost(newPost, existingPosts) {
+  return newPost.id !== null && existingPosts.some(post => newPost.id === post.cursor);
+}
+
 class PostAdd extends React.Component {
   onSubmit(values) {
     const { addPost } = this.props;
@@ -44,13 +48,17 @@ const PostAddWithApollo = compose(
           },
         },
         updateQueries: {
-          getPosts: (prev, { mutationResult }) => {
+          getPosts: (prev, { mutationResult: { data: { addPost } } }) => {
+            if (isDuplicatePost(addPost, prev.postsQuery.edges)) {
+              return prev;
+            }
+
             const edge = {
-              cursor: mutationResult.data.addPost.id,
+              cursor: addPost.id,
               node: {
-                id: mutationResult.data.addPost.id,
-                title: mutationResult.data.addPost.title,
-                content: mutationResult.data.addPost.content,
+                id: addPost.id,
+                title: addPost.title,
+                content: addPost.content,
                 comments: [],
                 __typename: 'Post'
               },

--- a/src/ui/post/containers/post_add.jsx
+++ b/src/ui/post/containers/post_add.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import { graphql, compose } from 'react-apollo'
 import update from 'react-addons-update'
 import { Link } from 'react-router-dom'
@@ -31,19 +32,19 @@ class PostAdd extends React.Component {
 
 PostAdd.propTypes = {
   addPost: React.PropTypes.func.isRequired,
+  endCursor: React.PropTypes.string.isRequired,
 };
 
 const PostAddWithApollo = compose(
   graphql(POST_ADD, {
-    props: ({ ownProps, mutate }) => ({
+    props: ({ ownProps: { endCursor, history }, mutate }) => ({
       addPost: (title, content) => mutate({
-        variables: { input: { title, content } },
+        variables: { input: { title, content, endCursor } },
         optimisticResponse: {
           addPost: {
             id: -1,
             title: title,
             content: content,
-            comments: [],
             __typename: 'Post',
           },
         },
@@ -59,7 +60,6 @@ const PostAddWithApollo = compose(
                 id: addPost.id,
                 title: addPost.title,
                 content: addPost.content,
-                comments: [],
                 __typename: 'Post'
               },
               __typename: 'Edges'
@@ -77,9 +77,12 @@ const PostAddWithApollo = compose(
             });
           }
         }
-      }).then(() => ownProps.history.push('/posts')),
+      }).then(() => history.push('/posts')),
     })
   })
 )(PostAdd);
 
-export default PostAddWithApollo;
+export default connect(
+  (state) => ({ endCursor: state.post.endCursor }),
+  (dispatch) => ({}),
+)(PostAddWithApollo);

--- a/src/ui/post/containers/post_comments.jsx
+++ b/src/ui/post/containers/post_comments.jsx
@@ -45,13 +45,13 @@ class PostComments extends React.Component {
 
           if (mutation === 'CREATED') {
             if (!isDuplicateComment(node, prev.post.comments)) {
-            newResult = update(prev, {
-              post: {
-                comments: {
-                  $push: [ node ],
+              newResult = update(prev, {
+                post: {
+                  comments: {
+                    $push: [ node ],
+                  }
                 }
-              }
-            });
+              });
             }
           } else if (mutation === 'DELETED') {
             const index = prev.post.comments.findIndex(x => x.id === id);

--- a/src/ui/post/containers/post_comments.jsx
+++ b/src/ui/post/containers/post_comments.jsx
@@ -30,7 +30,6 @@ class PostComments extends React.Component {
 
     // Check if props have changed and, if necessary, stop the subscription
     if (this.subscription && postId !== nextProps.postId) {
-      this.subscription.unsubscribe();
       this.subscription = null;
     }
 

--- a/src/ui/post/containers/post_comments.jsx
+++ b/src/ui/post/containers/post_comments.jsx
@@ -21,21 +21,24 @@ class PostComments extends React.Component {
     super(props);
 
     props.onCommentSelect({ id: null, content: '' });
+
     this.subscription = null;
   }
 
   componentWillReceiveProps(nextProps) {
+    const { postId, subscribeToMore } = this.props;
+
     // Check if props have changed and, if necessary, stop the subscription
-    if (this.subscription && this.props.postId !== nextProps.postId) {
+    if (this.subscription && postId !== nextProps.postId) {
       this.subscription.unsubscribe();
       this.subscription = null;
     }
 
     // Subscribe or re-subscribe
     if (!this.subscription) {
-      this.subscription = nextProps.subscribeToMore({
+      this.subscription = subscribeToMore({
         document: COMMENT_SUBSCRIPTION,
-        variables: { postId: nextProps.postId },
+        variables: { postId: postId },
         updateQuery: (prev, { subscriptionData: { data: { commentUpdated: { mutation, id, node } } } }) => {
 
           let newResult;
@@ -72,12 +75,6 @@ class PostComments extends React.Component {
         },
         onError: (err) => console.error(err),
       });
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.subscription) {
-      this.subscription.unsubscribe();
     }
   }
 

--- a/src/ui/post/containers/post_edit.jsx
+++ b/src/ui/post/containers/post_edit.jsx
@@ -5,10 +5,39 @@ import { Link } from 'react-router-dom'
 import PostForm from '../components/post_form'
 import PostComments from './post_comments'
 
-import POST_EDIT from '../graphql/post_edit.graphql'
 import POST_QUERY from '../graphql/post_get.graphql'
+import POST_EDIT from '../graphql/post_edit.graphql'
+import POST_SUBSCRIPTION from '../graphql/post_subscription.graphql'
 
 class PostEdit extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.subscription = null;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { post, loading, subscribeToMore } = this.props;
+
+    // Check if props have changed and, if necessary, stop the subscription
+    if (this.subscription && post.id !== nextProps.post.id) {
+      this.subscription.unsubscribe();
+      this.subscription = null;
+    }
+
+    // Subscribe or re-subscribe
+    if (!this.subscription && !loading) {
+      this.subscription = subscribeToMore({
+        document: POST_SUBSCRIPTION,
+        variables: { id: post.id },
+        updateQuery: (prev) => {
+          return prev;
+        },
+        onError: (err) => console.error(err),
+      });
+    }
+  }
+
   onSubmit(values) {
     const { post, editPost } = this.props;
 

--- a/src/ui/post/containers/post_edit.jsx
+++ b/src/ui/post/containers/post_edit.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import { graphql, compose } from 'react-apollo'
 import { Link } from 'react-router-dom'
 
@@ -71,6 +72,7 @@ PostEdit.propTypes = {
   editPost: React.PropTypes.func.isRequired,
   match: React.PropTypes.object.isRequired,
   subscribeToMore: React.PropTypes.func.isRequired,
+  endCursor: React.PropTypes.string.isRequired,
 };
 
 const PostEditWithApollo = compose(
@@ -85,12 +87,15 @@ const PostEditWithApollo = compose(
     }
   }),
   graphql(POST_EDIT, {
-    props: ({ ownProps, mutate }) => ({
+    props: ({ ownProps: { endCursor, history }, mutate }) => ({
       editPost: (id, title, content) => mutate({
-        variables: { input: { id, title, content } }
-      }).then(() => ownProps.history.push('/posts')),
+        variables: { input: { id, title, content, endCursor } }
+      }).then(() => history.push('/posts')),
     })
   })
 )(PostEdit);
 
-export default PostEditWithApollo;
+export default connect(
+  (state) => ({ endCursor: state.post.endCursor }),
+  (dispatch) => ({}),
+)(PostEditWithApollo);

--- a/src/ui/post/containers/post_edit.jsx
+++ b/src/ui/post/containers/post_edit.jsx
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom'
 
 import PostForm from '../components/post_form'
 import PostComments from './post_comments'
-
 import POST_QUERY from '../graphql/post_get.graphql'
 import POST_EDIT from '../graphql/post_edit.graphql'
 import POST_SUBSCRIPTION from '../graphql/post_subscription.graphql'
@@ -22,7 +21,6 @@ class PostEdit extends React.Component {
 
     // Check if props have changed and, if necessary, stop the subscription
     if (this.subscription && post.id !== nextProps.post.id) {
-      this.subscription.unsubscribe();
       this.subscription = null;
     }
 
@@ -96,6 +94,5 @@ const PostEditWithApollo = compose(
 )(PostEdit);
 
 export default connect(
-  (state) => ({ endCursor: state.post.endCursor }),
-  (dispatch) => ({}),
+  (state) => ({ endCursor: state.post.endCursor })
 )(PostEditWithApollo);

--- a/src/ui/post/containers/post_list.jsx
+++ b/src/ui/post/containers/post_list.jsx
@@ -86,7 +86,6 @@ const PostListWithApollo = compose(
       let after = props.endCursor || 0;
       return {
         variables: { first: 10, after: after },
-        pollInterval: 10000
       };
     },
     props: ({ data }) => {

--- a/src/ui/post/containers/post_list.jsx
+++ b/src/ui/post/containers/post_list.jsx
@@ -86,6 +86,7 @@ const PostListWithApollo = compose(
       let after = props.endCursor || 0;
       return {
         variables: { first: 10, after: after },
+        pollInterval: 10000
       };
     },
     props: ({ data }) => {

--- a/src/ui/post/graphql/post.graphql
+++ b/src/ui/post/graphql/post.graphql
@@ -1,10 +1,5 @@
-#import "./comment.graphql"
-
 fragment PostInfo on Post {
     id
     title
     content
-    comments {
-        ... CommentInfo
-    }
 }

--- a/src/ui/post/graphql/post_comment_subscription.graphql
+++ b/src/ui/post/graphql/post_comment_subscription.graphql
@@ -4,6 +4,7 @@ subscription onCommentUpdated($postId: ID!) {
     commentUpdated(postId: $postId) {
         mutation
         id
+        postId
         node {
             ... CommentInfo
         }

--- a/src/ui/post/graphql/post_delete.graphql
+++ b/src/ui/post/graphql/post_delete.graphql
@@ -1,5 +1,5 @@
-mutation deletePost($id: ID!) {
-    deletePost(id: $id) {
+mutation deletePost($input: DeletePostInput!) {
+    deletePost(input: $input) {
         id
     }
 }

--- a/src/ui/post/graphql/post_get.graphql
+++ b/src/ui/post/graphql/post_get.graphql
@@ -1,7 +1,11 @@
 #import "./post.graphql"
+#import "./comment.graphql"
 
 query getPost($id: ID!) {
     post(id: $id) {
         ... PostInfo
+        comments {
+            ... CommentInfo
+        }
     }
 }

--- a/src/ui/post/graphql/post_subscription.graphql
+++ b/src/ui/post/graphql/post_subscription.graphql
@@ -1,0 +1,7 @@
+subscription onPostUpdated($id: ID!) {
+    postUpdated(id: $id) {
+        id
+        title
+        content
+    }
+}

--- a/src/ui/post/graphql/post_subscription.graphql
+++ b/src/ui/post/graphql/post_subscription.graphql
@@ -1,7 +1,7 @@
+#import "./post.graphql"
+
 subscription onPostUpdated($id: ID!) {
     postUpdated(id: $id) {
-        id
-        title
-        content
+        ... PostInfo
     }
 }

--- a/src/ui/post/graphql/posts_subscription.graphql
+++ b/src/ui/post/graphql/posts_subscription.graphql
@@ -1,12 +1,12 @@
+#import "./post.graphql"
+
 subscription onPostUpdated($endCursor: ID!) {
     postsUpdated(endCursor: $endCursor) {
         mutation
         id
         endCursor
         node {
-            id
-            title
-            content
+            ... PostInfo
         }
     }
 }

--- a/src/ui/post/graphql/posts_subscription.graphql
+++ b/src/ui/post/graphql/posts_subscription.graphql
@@ -1,0 +1,12 @@
+subscription onPostUpdated($endCursor: ID!) {
+    postsUpdated(endCursor: $endCursor) {
+        mutation
+        id
+        endCursor
+        node {
+            id
+            title
+            content
+        }
+    }
+}

--- a/src/ui/post/reducers/post_reducers.js
+++ b/src/ui/post/reducers/post_reducers.js
@@ -1,9 +1,9 @@
 const defaultState = {
   endCursor: '0',
-  comment: {id: null, content: ''}
+  comment: { id: null, content: '' }
 };
 
-export default function(state = defaultState, action) {
+export default function (state = defaultState, action) {
   switch (action.type) {
     case 'COMMENT_SELECT':
       return {

--- a/src/ui/post/reducers/post_reducers.js
+++ b/src/ui/post/reducers/post_reducers.js
@@ -1,14 +1,20 @@
 const defaultState = {
+  endCursor: '0',
   comment: {id: null, content: ''}
 };
 
 export default function(state = defaultState, action) {
   switch (action.type) {
     case 'COMMENT_SELECT':
-
       return {
         ...state,
         comment: action.value
+      };
+
+    case 'POST_ENDCURSOR':
+      return {
+        ...state,
+        endCursor: action.value
       };
 
     default:


### PR DESCRIPTION
Added subscriptions on `editPost`.

My idea is not to have full subscriptions on all posts, but rather only on the one you are currently editing. I think making subscriptions work properly with pagination and possible sorting later on, might be quite a challenge. Also what if someone deletes a post you are editing, or just viewing. Also `pollInterval` every 10 seconds should do the trick of keeping the list up to date. This way you also showcase different solutions on how to update data.

Full subscriptions on comments I thing is great in case you would use comments as some sort of a chat.

Maybe I could add subscriptions on `num of comments` on all currently viewd posts, so this would be updated real time?

TODO:
- remember `Load more` variables, so if you have more than 10 records shown, polling does not reset this.

@vlasenko Do you agree with this approach?
 