### PR TITLE
restructure schema, resolvers, subscriptions imports

### DIFF
--- a/src/server/api/graphqls/index.js
+++ b/src/server/api/graphqls/index.js
@@ -1,0 +1,8 @@
+import schema from './schema_def.graphqls'
+import postSchema from './post_def.graphqls'
+
+export default [
+  schema,
+  postSchema,
+  // add more schemas here
+];

--- a/src/server/api/resolvers/index.js
+++ b/src/server/api/resolvers/index.js
@@ -1,0 +1,6 @@
+import postResolvers from './post_resolvers'
+
+export default [
+  postResolvers,
+  // add more resolvers here
+];

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3,10 +3,9 @@ import { PubSub } from 'graphql-subscriptions'
 import { merge } from 'lodash'
 
 import log from '../../log'
-import postResolvers from './resolvers/post_resolvers'
 
-import schema from './graphqls/schema_def.graphqls'
-import postSchema from './graphqls/post_def.graphqls'
+import typeDefs from './graphqls'
+import allResolvers from './resolvers'
 
 export const pubsub = new PubSub();
 
@@ -33,10 +32,10 @@ const rootResolvers = {
   }
 };
 
-const resolvers = merge(rootResolvers, postResolvers);
+const resolvers = merge(rootResolvers, ...allResolvers);
 
 const executableSchema = makeExecutableSchema({
-  typeDefs: [postSchema, schema],
+  typeDefs,
   resolvers,
 });
 

--- a/src/server/api/subscription_functions/index.js
+++ b/src/server/api/subscription_functions/index.js
@@ -1,0 +1,6 @@
+import postSubscriptions from './post_subscriptions'
+
+export default [
+  postSubscriptions,
+  // add more subscription setup functions here
+];

--- a/src/server/api/subscription_functions/post_subscriptions.js
+++ b/src/server/api/subscription_functions/post_subscriptions.js
@@ -16,4 +16,4 @@ const postSetupFunctions = {
   }),
 };
 
-export default  postSetupFunctions;
+export default postSetupFunctions;

--- a/src/server/api/subscriptions.js
+++ b/src/server/api/subscriptions.js
@@ -2,8 +2,7 @@ import { SubscriptionManager } from 'graphql-subscriptions'
 import { merge } from 'lodash'
 
 import schema, { pubsub } from './schema'
-
-import postSetupFunctions from './subscriptions/post_subscriptions'
+import allSetupFunctions from './subscription_functions'
 
 const rootSetupFunctions = {
   countUpdated: () => ({
@@ -12,7 +11,7 @@ const rootSetupFunctions = {
   })
 };
 
-const setupFunctions = merge(rootSetupFunctions, postSetupFunctions);
+const setupFunctions = merge(rootSetupFunctions, ...allSetupFunctions);
 
 const subscriptionManager = new SubscriptionManager({
   schema,


### PR DESCRIPTION
I would like to restructure schema, resolvers, subscriptions imports so that it might be easier later to automate adding or removing of examples or other modules.

This might also have less conflicts when merging newer versions of this starter kit.

@vlasenko What do you think?