### PR TITLE
disable persistGraphQL in DEV mode

### DIFF
--- a/src/server/api_server.js
+++ b/src/server/api_server.js
@@ -28,7 +28,7 @@ app.use(bodyParser.json());
 app.use('/', express.static(settings.frontendBuildDir, { maxAge: '180 days' }));
 
 let queryMap = null;
-if (settings.persistGraphQL) {
+if (!__DEV__ && settings.persistGraphQL) {
   // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
   queryMap = require('persisted_queries.json');
   const invertedMap = invert(queryMap);


### PR DESCRIPTION
Thank you for the awesome project!

I just wanted to run queries on graphiql but got blocked by persistGraphQL on, even in DEV mode.
So I'm disabling it when it's DEV mode. 

Simply close this if you don't think it's a problem.

![image](https://cloud.githubusercontent.com/assets/1251296/24890096/b92f7186-1e22-11e7-9bd9-38aa7f3ae798.png)
