### PR TITLE
fix validateDOMNesting

### DIFF
--- a/src/server/middleware/html.jsx
+++ b/src/server/middleware/html.jsx
@@ -19,12 +19,12 @@ const Html = ({ content, state, assetMap, css }) => {
       <meta name="msapplication-config" content={`/${assetMap["browserconfig.xml"]}`}/>
       <meta name="theme-color" content="#ffffff"/>
       {!__DEV__ && <link rel="stylesheet" type="text/css" href={`/${assetMap['bundle.css']}`}/>}
-      {__DEV__ &&
+      {!!__DEV__ &&
       <style dangerouslySetInnerHTML={{
         __html: require('client/styles/styles.scss')._getCss()
       }}/>
       }
-      {css && <style dangerouslySetInnerHTML={{ __html: css }}/>}
+      {!!css && <style dangerouslySetInnerHTML={{ __html: css }}/>}
     </head>
     <body>
     <div id="content" dangerouslySetInnerHTML={{ __html: content || "" }}/>


### PR DESCRIPTION
ref: https://github.com/facebook/react/issues/5071

I am not 100% sure this is right fix 

```
webpack-for-frontend bundle is now VALID.
webpack-for-frontend Time: 267ms
Warning: validateDOMNesting(...): Whitespace text nodes cannot appear as a child of <head>. Make sure you don't have any extra whitespace between tags on each line of your source code. See Html > head > #text.
webpack-for-frontend bundle is now INVALID.
webpack-for-frontend bundle is now VALID.
```
Please close this if it's not 

Thanks guys.