### PR TITLE
change graphql (post) edge type name not to be so generic

### DIFF
--- a/src/client/modules/post/containers/post_int.spec.js
+++ b/src/client/modules/post/containers/post_int.spec.js
@@ -35,7 +35,7 @@ const mocks = {
         edges.push({
           cursor: `${i}`,
           node: createNode(i),
-          __typename: "Edges"
+          __typename: "PostEdges"
         });
       }
       return {
@@ -44,7 +44,7 @@ const mocks = {
         pageInfo: {
           endCursor: edges[edges.length - 1].cursor,
           hasNextPage: true,
-          __typename: "PageInfo"
+          __typename: "PostPageInfo"
         },
         __typename: "PostsQuery"
       };

--- a/src/client/modules/post/containers/post_list.jsx
+++ b/src/client/modules/post/containers/post_list.jsx
@@ -18,7 +18,7 @@ export function AddPost(prev, node) {
   const edge = {
     cursor: node.id,
     node: node,
-    __typename: 'Edges'
+    __typename: 'PostEdges'
   };
 
   return update(prev, {

--- a/src/server/modules/post/post_api_int.spec.js
+++ b/src/server/modules/post/post_api_int.spec.js
@@ -25,9 +25,9 @@ describe('Post and comments example API works', () => {
         edges: [{
           cursor: "20",
           node: {id: "20", title: "Post title 20", content: "Post content 20", __typename: "Post"},
-          __typename: "Edges"
+          __typename: "PostEdges"
         }],
-        pageInfo: {endCursor: "20", hasNextPage: true, __typename: "PageInfo"},
+        pageInfo: {endCursor: "20", hasNextPage: true, __typename: "PostPageInfo"},
         __typename: "PostsQuery"
       }
     });

--- a/src/server/modules/post/schema.graphqls
+++ b/src/server/modules/post/schema.graphqls
@@ -13,13 +13,13 @@ type Comment {
 }
 
 # Edges for PostsQuery
-type Edges {
+type PostEdges {
   node: Post
   cursor: ID
 }
 
 # PageInfo for PostsQuery
-type PageInfo {
+type PostPageInfo {
   endCursor: ID
   hasNextPage: Boolean
 }
@@ -27,8 +27,8 @@ type PageInfo {
 # Posts relay-style pagination query
 type PostsQuery {
   totalCount: Int
-  edges: [Edges]
-  pageInfo: PageInfo
+  edges: [PostEdges]
+  pageInfo: PostPageInfo
 }
 
 extend type Query {


### PR DESCRIPTION
- I ran into this problem when trying to add few other components in my app and had to spend some time debugging the issue. The problem is we are using `Edges` `PageInfo` as a `type` name for the post module, which is too generic and often mistaken by `edges` in the node query.
- I have added an explicit type name for post module to avoid confusion in the future.

FYI: http://stackoverflow.com/questions/33323894/why-are-edges-required-in-a-relay-graphql-connection (Also saw the explicit naming convention over here)