### PR TITLE
ES6 syntax refactoring

### DIFF
--- a/src/client/modules/counter/containers/counter.jsx
+++ b/src/client/modules/counter/containers/counter.jsx
@@ -36,7 +36,7 @@ class Counter extends React.Component {
     }
   }
 
-  handleReduxIncrement(e) {
+  handleReduxIncrement = (e) => {
     let value;
     if (e && e.target) {
       value = e.target.value;
@@ -89,7 +89,7 @@ class Counter extends React.Component {
           Current reduxCount, is {reduxCount}. This is being stored client-side with Redux.
           <br/>
           <br/>
-          <Button id="redux-button" color="primary" value="1" onClick={this.handleReduxIncrement.bind(this)}>
+          <Button id="redux-button" color="primary" value="1" onClick={this.handleReduxIncrement}>
             Click to increase reduxCount
           </Button>
         </div>

--- a/src/client/modules/post/containers/post_add.jsx
+++ b/src/client/modules/post/containers/post_add.jsx
@@ -9,7 +9,7 @@ import POST_ADD from '../graphql/post_add.graphql';
 import { AddPost } from './post_list';
 
 class PostAdd extends React.Component {
-  onSubmit(values) {
+  onSubmit = (values) => {
     const { addPost } = this.props;
 
     addPost(values.title, values.content);
@@ -20,7 +20,7 @@ class PostAdd extends React.Component {
       <div>
         <Link to="/posts">Back</Link>
         <h2>Create Post</h2>
-        <PostForm onSubmit={this.onSubmit.bind(this)}/>
+        <PostForm onSubmit={this.onSubmit}/>
       </div>
     );
   }

--- a/src/client/modules/post/containers/post_comments.jsx
+++ b/src/client/modules/post/containers/post_comments.jsx
@@ -121,7 +121,7 @@ class PostComments extends React.Component {
     deleteComment(id);
   }
 
-  onSubmit(values) {
+  onSubmit = (values) => {
     const { addComment, editComment, postId, comment, onCommentSelect, onFormSubmitted } = this.props;
 
     if (comment.id === null) {
@@ -141,7 +141,7 @@ class PostComments extends React.Component {
     return (
       <div>
         <h3>Comments</h3>
-        <CommentForm postId={postId} onSubmit={this.onSubmit.bind(this)} initialValues={comment}/>
+        <CommentForm postId={postId} onSubmit={this.onSubmit} initialValues={comment}/>
         <h1/>
         <ListGroup>{this.renderComments()}</ListGroup>
       </div>

--- a/src/client/modules/post/containers/post_edit.jsx
+++ b/src/client/modules/post/containers/post_edit.jsx
@@ -47,7 +47,7 @@ class PostEdit extends React.Component {
     }
   }
 
-  onSubmit(values) {
+  onSubmit = (values) => {
     const { post, editPost } = this.props;
 
     editPost(post.id, values.title, values.content);
@@ -65,7 +65,7 @@ class PostEdit extends React.Component {
         <div>
           <Link id="back-button" to="/posts">Back</Link>
           <h2>Edit Post</h2>
-          <PostForm onSubmit={this.onSubmit.bind(this)} initialValues={post}/>
+          <PostForm onSubmit={this.onSubmit} initialValues={post}/>
           <br/>
           <PostComments postId={match.params.id} comments={post.comments} subscribeToMore={subscribeToMore}/>
         </div>


### PR DESCRIPTION
- Using fat arrow function and class properties for binding methods.
- Reason for this change is `Function.prototype.bind()` methods are getting obsolete and ES6 "preferred" way is to use fat arrow syntax for private methods.