### PR TITLE
integrate google analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ for better security and less bandwidth.
 
 - Declarative/dynamic `head` section, using [React Helmet]
 
+- Google Analytics integration using [React GA]
+
 - Full CRUD funcionality with Subscriptions in post example, with [ReduxForm]
 
 ## Contributors
@@ -281,3 +283,4 @@ Copyright © 2016, 2017 [SysGears INC]. This source code is licensed under the [
 [GraphQL Cursor Pagination]: https://medium.com/@gethylgeorge/infinite-scrolling-in-react-using-apollo-and-react-virtualized-graphql-cursor-pagination-bf80617a8a1a#.jkmmu9qz8
 [Relay-style cursor pagination]: http://dev.apollodata.com/react/pagination.html#relay-cursors
 [React Helmet]: https://github.com/nfl/react-helmet
+[React GA]: https://github.com/react-ga/react-ga

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react": "^15.5.4",
     "react-apollo": "^1.2.0",
     "react-dom": "^15.5.4",
+    "react-ga": "^2.2.0",
     "react-helmet": "^5.1.3",
     "react-hot-loader": "^3.0.0-beta.6",
     "react-redux": "^5.0.4",

--- a/src/client/app/main.jsx
+++ b/src/client/app/main.jsx
@@ -8,6 +8,7 @@ import { addPersistedQueries } from 'persistgraphql';
 import { SubscriptionClient, addGraphQLSubscriptions } from 'subscriptions-transport-ws';
 // eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies, import/extensions
 import queryMap from 'persisted_queries.json';
+import ReactGA from 'react-ga';
 
 import createApolloClient from '../../common/apollo_client';
 import createReduxStore from '../../common/redux_store';
@@ -52,6 +53,14 @@ if (window.__APOLLO_STATE__) {
 }
 
 const history = createHistory();
+
+// Initialize Google Analytics and send events on each location change 
+ReactGA.initialize('UA-000000-01'); // Replace your Google tracking code here
+
+history.listen((location) => {
+  ReactGA.set({ page: location.pathname });
+  ReactGA.pageview(location.pathname);
+});
 
 const store = createReduxStore(initialState, client, routerMiddleware(history));
 


### PR DESCRIPTION
- Integrate Google analytics in the kit
- Send page tracking events on each location change
- According to the office docs [react ga](https://github.com/react-ga/react-ga), we have to use `onUpdate` method on the `Router`. However, Router V4 does not support `onUpdate` method anymore thus I have used `history` to do the same.